### PR TITLE
Negative data leading to std < 0

### DIFF
--- a/geobipy/src/classes/data/datapoint/DataPoint.py
+++ b/geobipy/src/classes/data/datapoint/DataPoint.py
@@ -275,7 +275,7 @@ class DataPoint(Point):
         assert all(relativeErr > 0.0), ValueError("relativeErr must be > 0.0")
         assert all(additiveErr > 0.0), ValueError("additiveErr must be > 0.0")
 
-        tmp = (relativeErr * self._data)**2.0 + additiveErr**2.0
+        tmp = (relativeErr * np.absolute(self._data) )**2.0 + additiveErr**2.0
 
         if self._predictedData.hasPrior():
             self._predictedData.prior.variance[:] = tmp[self.iActive]


### PR DESCRIPTION
changed error calculation to use absolute values of data in order to account for negative data that produce std < 0.  Should still warn user in .out file if data contain negative values larger in magnitude than -10 or so .. these may be related to susceptibility, not just low-amplitude noise